### PR TITLE
GitHub のセキュリティアラートを解決

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -784,7 +784,7 @@
     webpack "^4.26.1"
     webpack-bundle-analyzer "^3.0.3"
     webpack-chain "^4.11.0"
-    webpack-dev-server "^3.1.10"
+    webpack-dev-server "^3.1.11"
     webpack-merge "^4.1.4"
     yorkie "^2.0.0"
 


### PR DESCRIPTION
- 概要
GitHub からセキュリティアラートが出ているためその解消

- やったこと
webpack-dev-server のバージョンを 3.1.10 から 3.1.11 に変更

- 確認したこと
特になし