### PR TITLE
UI 修正

### DIFF
--- a/src/components/TheWordUnderNoisePanel.vue
+++ b/src/components/TheWordUnderNoisePanel.vue
@@ -15,16 +15,6 @@
       </v-toolbar>
     </v-card>
 
-    <v-layout justify-center text-xs-center mt-2 wrap>
-      <v-flex xs6>
-        <v-btn
-          class="btn-large"
-          :large="true"
-          :disabled="played"
-          @click="reOrder"
-          >番号再生成</v-btn>
-      </v-flex>
-    </v-layout>
     <v-layout text-xs-center justify-center mt-2 wrap>
       <v-flex xs3>
         <v-btn
@@ -242,7 +232,7 @@ function buildAudioTable(audioList, remainingAudioNumber) {
   const numberArray = shuffleArray(Array.from({ length: remainingAudioNumber }).map((_, i) => i));
   const labeledAudioList = audioList.map(audio => ({
     audio,
-    label: audio.done ? '済' : numberArray.pop(),
+    label: numberArray.pop(),
   }));
 
   return splitArray(labeledAudioList, 6);
@@ -310,9 +300,6 @@ export default {
 
       this.currentAudio.label = '再';
       playAudio(this.currentAudio.audio.buffer);
-    },
-    reOrder() {
-      this.audioTable = buildAudioTable(this.audioList, this.remainingAudioNumber);
     },
     answer(isCorrect) {
       this.currentAudio.audio.done = true;

--- a/src/router.js
+++ b/src/router.js
@@ -155,7 +155,7 @@ export default new Router({
       path: '/multiple-sound-listening-inspection',
       name: 'multipleSoundListeningInspection',
       props: {
-        title: '複数音声下聴取',
+        title: '複数音声下聴取検査',
         backPath: 'home',
         audioDirPath: '複数音声聴取/',
         columnNumber: 1,


### PR DESCRIPTION
- 概要
UI 修正

- やったこと
雑音下単語聴取検査から「番号再生」ボタンを削除
複数音声聴取検査の脱字を修正

- 確認したこと
 - [x] 雑音下単語聴取検査画面の「番号再生」ボタンが削除されているか
 - [x] 雑音下単語聴取検査が問題なく動作するか
 - [x] 複数音声聴取検査のパネルタイトルが正しく変更されているか