### PR TITLE
聴覚的注意検査の出力ファイルに平均応答時間を追加

### DIFF
--- a/src/services/FileService.js
+++ b/src/services/FileService.js
@@ -103,13 +103,22 @@ export async function outputCsvForAuditoryAttentionInspection(inspectionTitle, r
     { id: 'time', title: '応答時間[ms]' },
   ];
   const body = resultList;
+  const correctAnswerList = resultList.filter(result => result.result === '正');
+  const averageTimeOfCorrectAnswer = correctAnswerList
+    .map(result => result.time)
+    .reduce((prev, current) => prev + current) / correctAnswerList.length;
+  const wrongAnswerList = resultList.filter(result => result.result === '誤');
+  const averageTimeOfWrongAnswer = wrongAnswerList
+    .map(result => result.time)
+    .reduce((prev, current) => prev + current) / wrongAnswerList.length;
   const correctNumber = resultList.filter(_result => _result.result === '正').length;
   const wrongNumber = resultList.filter(_result => _result.result === '誤').length;
-  const appendData = ['正答数,誤答数,正答率(正答数 / 20)'].concat(Object.values({
-    correctNumber,
-    wrongNumber,
-    correctPercent: `${Math.round(correctNumber / 20 * 100)}%`,
-  }).join(',')).join('\n');
+  const appendData = [
+    '正答数,誤答数,正答率(正答数 / 20)',
+    `${correctNumber},${wrongNumber},${Math.round(correctNumber / 20 * 100)}%`,
+    '正答 応答時間平均,誤答 応答時間平均',
+    `${averageTimeOfCorrectAnswer},${averageTimeOfWrongAnswer}`,
+  ].join('\n');
 
   await outputCsv(inspectionTitle, header, body, appendData);
 }


### PR DESCRIPTION
## 概要/目的
聴覚的注意検査の出力ファイルに正答したときの応答時間の平均と誤答したときの応答時間の平均を追加

## やったこと
聴覚的注意検査の結果出力に応答時間の平均を出力する機能を追加

## 確認したこと
- [x] 正しくデータが出力できているか

## 備考