### PR TITLE
状態が2つ/3つある検査で状態毎の正答率を出力するように変更

### DIFF
--- a/src/components/globals/InspectionPanel.vue
+++ b/src/components/globals/InspectionPanel.vue
@@ -124,7 +124,6 @@ export default {
   props: [
     'title',
     'backPath',
-    'audioDirPath',
     'answerButtonList',
     'resultListHeader',
     'audioList',

--- a/src/services/FileService.js
+++ b/src/services/FileService.js
@@ -53,13 +53,22 @@ export async function outputCsvForInspectionPanel(inspectionTitle, csvHeader, bo
     });
     return row;
   });
+  const columnNumber = bodyOrigin[0].statuses.length;
 
   const totalInspectionNumber = bodyOrigin
     .filter(elem => elem.statuses.every(status => status !== '')).length;
-  const totalCurrectAnserNumber = bodyOrigin
-    .filter(elem => elem.statuses.every(status => status === '正答')).length;
-  const appendData = `正答率  ${Math.round(totalCurrectAnserNumber / totalInspectionNumber * 100)}%`;
+  const statusesList = bodyOrigin.map(elem => elem.statuses);
+  const correctNumberPerStatus = Array(columnNumber).fill(0);
 
+  statusesList.forEach((statuses) => {
+    statuses.forEach((status, index) => {
+      correctNumberPerStatus[index] += status === '正答' ? 1 : 0;
+    });
+  });
+
+  const correctAnserRatePerStatus = correctNumberPerStatus
+    .map(correctNumber => `${Math.round(correctNumber / totalInspectionNumber * 100)}%`);
+  const appendData = ['正答率'].concat(correctAnserRatePerStatus).join(',');
   await outputCsv(inspectionTitle, header, body, appendData);
 }
 


### PR DESCRIPTION
## 概要/目的
現在は状態が2つ/3つある検査ではすべての状態が「正答」になっているものを正答として正答率を計算しているが, 状態毎に正答率を計算するように変更

## やったこと
ourputCsvForInspectionPanel に状態毎に正答率を計算し出力する機能を追加

## 確認したこと
- [x] 状態数が1つ検査で正しく正答率が計算できているか
- [x] 状態数が2つ検査で正しく正答率が計算できているか
- [x] 状態数が3つ検査で正しく正答率が計算できているか

## 備考