### PR TITLE
聴覚的注意検査の応答時間平均を丸める処理を追加

### DIFF
--- a/src/services/FileService.js
+++ b/src/services/FileService.js
@@ -113,13 +113,17 @@ export async function outputCsvForAuditoryAttentionInspection(inspectionTitle, r
   ];
   const body = resultList;
   const correctAnswerList = resultList.filter(result => result.result === '正');
-  const averageTimeOfCorrectAnswer = correctAnswerList
-    .map(result => result.time)
-    .reduce((prev, current) => prev + current) / correctAnswerList.length;
+  const averageTimeOfCorrectAnswer = Math.round(
+    correctAnswerList
+      .map(result => result.time)
+      .reduce((prev, current) => prev + current) / correctAnswerList.length,
+  );
   const wrongAnswerList = resultList.filter(result => result.result === '誤');
-  const averageTimeOfWrongAnswer = wrongAnswerList
-    .map(result => result.time)
-    .reduce((prev, current) => prev + current) / wrongAnswerList.length;
+  const averageTimeOfWrongAnswer = Math.round(
+    wrongAnswerList
+      .map(result => result.time)
+      .reduce((prev, current) => prev + current) / wrongAnswerList.length,
+  );
   const correctNumber = resultList.filter(_result => _result.result === '正').length;
   const wrongNumber = resultList.filter(_result => _result.result === '誤').length;
   const appendData = [


### PR DESCRIPTION
## 概要/目的
聴覚的注意検査の出力ファイルにある応答時間平均が桁数の多い小数になってしまい見づらいため, 値を丸める処理を追加

## やったこと
正答応答時間平均と誤答応答時間平均の計算に Math.round を適用

## 確認したこと
- [x] 正答応答時間平均の値が丸められているか
- [x] 誤答応答時間平均の値が丸められているか

## 備考