### PR TITLE
InspectionPanel をグローバルコンポーネントから外す

### DIFF
--- a/src/components/InspectionPanel.vue
+++ b/src/components/InspectionPanel.vue
@@ -117,8 +117,8 @@ import {
   internalNext,
   internalBack,
   playAudio,
-} from '../../services/InspectionService';
-import { outputCsvForInspectionPanel } from '../../services/FileService';
+} from '../services/InspectionService';
+import { outputCsvForInspectionPanel } from '../services/FileService';
 
 export default {
   props: [

--- a/src/main.js
+++ b/src/main.js
@@ -5,12 +5,10 @@ import App from './App.vue';
 import router from './router';
 import store from './store';
 import ListPanel from './components/globals/ListPanel.vue';
-import InspectionPanel from './components/globals/InspectionPanel.vue';
 
 Vue.config.productionTip = false;
 
 Vue.component('ListPanel', ListPanel);
-Vue.component('InspectionPanel', InspectionPanel);
 
 sync(store, router);
 

--- a/src/views/Inspection.vue
+++ b/src/views/Inspection.vue
@@ -11,6 +11,7 @@
 </template>
 
 <script>
+import InspectionPanel from '../components/InspectionPanel.vue';
 import {
   generateAnswerButtonList,
   generateResultListHeader,
@@ -37,6 +38,7 @@ export default {
     this.audioList = await generateAudioList(this.audioDirPath);
     this.resultList = generateResultList(this.audioList, this.columnNumber);
   },
+  components: { InspectionPanel },
 };
 </script>
 


### PR DESCRIPTION
## 概要/目的
現在 InspectionPanel がグローバルコンポーネントになっているが, その必要がないため, 通常のコンポーネントに変更

## やったこと
InspectionPanel を components/global/ から components/ に移動
ファイルの移動に伴い参照の修正

## 確認したこと
- [x] 変更前と変わらず動作するか

## 備考